### PR TITLE
Integrate HTTP API Device

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ This project ia a Python library that provides convenient client SDK for both De
 
 SDK supports:
 - Unencrypted and encrypted (TLS v1.2) connection
-- QoS 0 and 1
+- QoS 0 and 1 (MQTT only)
 - Automatic reconnect
 - All [Device MQTT](https://thingsboard.io/docs/reference/mqtt-api/) APIs provided by ThingsBoard
 - All [Gateway MQTT](https://thingsboard.io/docs/reference/gateway-mqtt-api/) APIs provided by ThingsBoard
-- All [Device HTTP](https://thingsboard.io/docs/reference/http-api/) APIs provided by ThingsBoard
+- Most [Device HTTP](https://thingsboard.io/docs/reference/http-api/) APIs provided by ThingsBoard
+  - Device Claiming and Firmware updates are not supported yet.
 
-SDK is based on Paho MQTT library. 
+The [Device MQTT](https://thingsboard.io/docs/reference/mqtt-api/) API and the [Gateway MQTT](https://thingsboard.io/docs/reference/gateway-mqtt-api/) API are base on the Paho MQTT library. The [Device HTTP](https://thingsboard.io/docs/reference/http-api/) API is based on the Requests library.
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.5",
     packages=["."],
-    install_requires=['paho-mqtt', 'jsonschema'],
+    install_requires=['paho-mqtt', 'jsonschema', 'requests'],
     download_url='https://github.com/thingsboard/thingsboard-python-client-sdk/archive/%s.tar.gz' % VERSION)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md')) as f:
     long_description = f.read()
 
-VERSION = "1.2"
+VERSION = "1.3"
 
 setup(
     version=VERSION,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     url="https://github.com/thingsboard/thingsboard-python-client-sdk",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     packages=["."],
     install_requires=['paho-mqtt', 'jsonschema', 'requests'],
     download_url='https://github.com/thingsboard/thingsboard-python-client-sdk/archive/%s.tar.gz' % VERSION)

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -38,3 +38,18 @@ class TBHTTPClient:
         """Request attributes from the ThingsBoard HTTP Device API."""
         params = {'client_keys': client_keys, 'shared_keys': shared_keys}
         return self.get_data(params=params, endpoint='attributes')
+
+    @classmethod
+    def provision(cls, host: str, device_name: str, device_key: str, device_secret: str):
+        """Initiate device provisioning through the ThingsBoard HTTP Device API."""
+        data = {
+            'deviceName': device_name,
+            'provisionDeviceKey': device_key,
+            'provisionDeviceSecret': device_secret
+        }
+        response = requests.post(f'{host}/api/v1/provision', json=data)
+        response.raise_for_status()
+        device = response.json()
+        if device['status'] == 'SUCCESS' and device['credentialsType'] == 'ACCESS_TOKEN':
+            return cls(host=host, token=device['credentialsValue'])
+        return None

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -215,14 +215,16 @@ class TBHTTPDevice:
         """
         self._publish_data(attributes, 'attributes')
 
-    def send_rpc(self, name: str, params: dict = None) -> dict:
+    def send_rpc(self, name: str, params: dict = None, rpc_id: int = None) -> dict:
         """Send RPC to ThingsBoard and return response.
 
         :param name: Name of the RPC method.
         :param params: Parameter for the RPC.
+        :param rpc_id: Specify an Id for this RPC.
         :return: A dictionary with the response.
         """
-        return self._publish_data({'method': name, 'params': params or {}}, 'rpc')
+        endpoint = f'rpc/{rpc_id}' if rpc_id else 'rpc'
+        return self._publish_data({'method': name, 'params': params or {}}, endpoint)
 
     def request_attributes(self, client_keys: list = None, shared_keys: list = None) -> dict:
         """Request attributes from ThingsBoard.

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -71,8 +71,12 @@ class TBHTTPDevice:
     @property
     def api_base_url(self) -> str:
         """Get the ThingsBoard API base URL."""
-        token = self.__config['token']
-        return f'{self.host}/api/v1/{token}'
+        return f'{self.host}/api/v1/{self.token}'
+
+    @property
+    def token(self) -> str:
+        """Get the device token."""
+        return self.__config['token']
 
     @property
     def logger(self) -> logging.Logger:

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -39,6 +39,35 @@ class TBHTTPClient:
     def __repr__(self):
         return f'<ThingsBoard ({self.host}) HTTP client {self.name}>'
 
+    def test_connection(self) -> bool:
+        """Test connection to the API.
+
+        :return: True if no errors occurred, False otherwise.
+        """
+        self.logger.debug('Start connection test')
+        success = False
+        try:
+            self.connect()
+        except requests.exceptions.Timeout as error:
+            self.logger.error('Connection timeout for host %s', self.host)
+            self.logger.debug(error)
+        except requests.exceptions.ConnectionError as error:
+            self.logger.error('Connection failed for host %s', self.host)
+            self.logger.debug(error)
+        except requests.exceptions.HTTPError as error:
+            self.logger.debug(error)
+            status_code = error.response.status_code
+            if status_code == 401:
+                self.logger.error('Error 401: Unauthorized. Check if token is correct.')
+            else:
+                self.logger.error('Error %s', status_code)
+        else:
+            self.logger.info('Connection test successful')
+            success = True
+        finally:
+            self.logger.debug('End connection test')
+        return success
+
     def connect(self):
         """Publish an empty telemetry data to ThingsBoard to test the connection."""
         self.publish_data({}, 'telemetry')

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -20,7 +20,7 @@ class TBHTTPClient:
         self.token = token
         self.name = name
         self.host = host
-        self.api_base_url = f'{self.host}/api/v1/{self.token}/'
+        self.api_base_url = f'{self.host}/api/v1/{self.token}'
         self.subscriptions = {
             'attributes': {
                 'event': threading.Event()

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -3,6 +3,14 @@ import threading
 import requests
 
 
+class TBHTTPAPIException(Exception):
+    """ThingsBoard HTTP Device API Exception class."""
+
+
+class TBProvisionFailure(TBHTTPAPIException):
+    """Exception raised if device provisioning failed."""
+
+
 class TBHTTPClient:
     """Thingsboard HTTP API Device"""
 
@@ -124,4 +132,4 @@ class TBHTTPClient:
         device = response.json()
         if device['status'] == 'SUCCESS' and device['credentialsType'] == 'ACCESS_TOKEN':
             return cls(host=host, token=device['credentialsValue'], name=device_name)
-        return None
+        raise TBProvisionFailure(device)

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -23,11 +23,9 @@ class TBHTTPClient:
     def __init__(self, host: str, token: str, name: str = None):
         self.session = requests.Session()
         self.session.headers.update({'Content-Type': 'application/json'})
-        self.token = token
-        self.name = name
-        self.host = host
-        self.timeout = 30
-        self.api_base_url = f'{self.host}/api/v1/{self.token}'
+        self.__config = {
+            'host': host, 'token': token, 'name': name, 'timeout': 30
+        }
         self.worker = {
             'publish': {
                 'queue': queue.Queue(),
@@ -50,6 +48,27 @@ class TBHTTPClient:
 
     def __repr__(self):
         return f'<ThingsBoard ({self.host}) HTTP client {self.name}>'
+
+    @property
+    def host(self) -> str:
+        """Get the ThingsBoard hostname"""
+        return self.__config['host']
+
+    @property
+    def name(self) -> str:
+        """Get the device name."""
+        return self.__config['name']
+
+    @property
+    def timeout(self)-> int:
+        """Get the connection timeout."""
+        return self.__config['timeout']
+
+    @property
+    def api_base_url(self) -> str:
+        """Get the ThingsBoard API base URL."""
+        token = self.__config['token']
+        return f'{self.host}/api/v1/{token}'
 
     @property
     def logger(self) -> logging.Logger:

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -5,7 +5,6 @@ import queue
 import time
 import typing
 from datetime import datetime, timezone
-from collections.abc import Callable
 import requests
 
 
@@ -248,7 +247,9 @@ class TBHTTPClient:
         }
         logger.debug('Timeout set to %ss', params['timeout']/1000)
         while not stop_event.is_set():
-            response = self.__session.get(url=url[endpoint], params=params, timeout=params['timeout'])
+            response = self.__session.get(url=url[endpoint],
+                                          params=params,
+                                          timeout=params['timeout'])
             if stop_event.is_set():
                 break
             if response.status_code == 408:  # Request timeout
@@ -260,7 +261,7 @@ class TBHTTPClient:
         stop_event.clear()
         logger.info('Stop subscription to %s updates', endpoint)
 
-    def subscribe(self, endpoint: str, callback: Callable[[dict], None] = None):
+    def subscribe(self, endpoint: str, callback: typing.Callable[[dict], None] = None):
         """Subscribe to updates.
 
         :param endpoint: The endpoint to subscribe.

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -20,6 +20,21 @@ class TBHTTPClient:
         response = self.session.post(f'{self.api_base_url}/{endpoint}', json=data)
         response.raise_for_status()
 
+    def get_data(self, params: dict, endpoint: str) -> dict:
+        """Send data to the ThingsBoard HTTP API."""
+        response = self.session.get(f'{self.api_base_url}/{endpoint}', params=params)
+        response.raise_for_status()
+        return response.json()
+
     def send_telemetry(self, telemetry: dict):
         """Publish telemetry to the ThingsBoard HTTP Device API."""
         self.publish_data(telemetry, 'telemetry')
+
+    def send_attributes(self, attributes: dict):
+        """Send attributes to the ThingsBoard HTTP Device API."""
+        self.publish_data(attributes, 'attributes')
+
+    def request_attributes(self, client_keys: list = None, shared_keys: list = None) -> dict:
+        """Request attributes from the ThingsBoard HTTP Device API."""
+        params = {'client_keys': client_keys, 'shared_keys': shared_keys}
+        return self.get_data(params=params, endpoint='attributes')

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -66,6 +66,8 @@ class TBHTTPClient:
                     break
                 if response.status_code == 408 and timeout:
                     break
+                if response.status_code == 504:  # Gateway Timeout
+                    continue  # Reconnect
                 response.raise_for_status()
                 callback(response.json())
             self.subscriptions['attributes']['event'].clear()
@@ -93,6 +95,8 @@ class TBHTTPClient:
                     break
                 if response.status_code == 408 and timeout:
                     break
+                if response.status_code == 504:  # Gateway Timeout
+                    continue  # Reconnect
                 response.raise_for_status()
                 callback(response.json())
             self.subscriptions['rpc']['event'].clear()

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -37,10 +37,11 @@ class TBHTTPClient:
         """Publish an empty telemetry data to ThingsBoard to test the connection."""
         self.publish_data({}, 'telemetry')
 
-    def publish_data(self, data: dict, endpoint: str):
+    def publish_data(self, data: dict, endpoint: str) -> dict:
         """Send data to the ThingsBoard HTTP API."""
         response = self.session.post(f'{self.api_base_url}/{endpoint}', json=data)
         response.raise_for_status()
+        return response.json() if response.content else {}
 
     def get_data(self, params: dict, endpoint: str) -> dict:
         """Send data to the ThingsBoard HTTP API."""

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -1,5 +1,6 @@
 """Thingsboard HTTP API Device module"""
 import threading
+from datetime import datetime, timezone
 import requests
 
 
@@ -49,9 +50,17 @@ class TBHTTPClient:
         response.raise_for_status()
         return response.json()
 
-    def send_telemetry(self, telemetry: dict):
+    def send_telemetry(self, telemetry: dict, timestamp: datetime = None):
         """Publish telemetry to the ThingsBoard HTTP Device API."""
-        self.publish_data(telemetry, 'telemetry')
+        if timestamp:
+            # Convert timestamp to UTC milliseconds as required by API specification.
+            payload = {
+                'ts': int(timestamp.replace(tzinfo=timezone.utc).timestamp()*1000),
+                'values': telemetry
+            }
+        else:
+            payload = telemetry
+        self.publish_data(payload, 'telemetry')
 
     def send_attributes(self, attributes: dict):
         """Send attributes to the ThingsBoard HTTP Device API."""

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -1,4 +1,4 @@
-"""ThingsBoard HTTP API Device module"""
+"""ThingsBoard HTTP API device module."""
 import threading
 import logging
 import queue
@@ -55,7 +55,7 @@ class TBHTTPDevice:
 
     @property
     def host(self) -> str:
-        """Get the ThingsBoard hostname"""
+        """Get the ThingsBoard hostname."""
         return self.__config['host']
 
     @property
@@ -64,7 +64,7 @@ class TBHTTPDevice:
         return self.__config['name']
 
     @property
-    def timeout(self)-> int:
+    def timeout(self) -> int:
         """Get the connection timeout."""
         return self.__config['timeout']
 
@@ -154,11 +154,16 @@ class TBHTTPDevice:
             self.logger.debug('End connection test')
         return success
 
-    def connect(self):
-        """Publish an empty telemetry data to ThingsBoard to test the connection."""
+    def connect(self) -> bool:
+        """Publish an empty telemetry data to ThingsBoard to test the connection.
+
+        :return: True if connected, false otherwise.
+        """
         if self.test_connection():
             self.logger.info('Connected to ThingsBoard')
             self.start_publish_worker()
+            return True
+        return False
 
     def _publish_data(self, data: dict, endpoint: str, timeout: int = None) -> dict:
         """Send POST data to ThingsBoard.
@@ -237,6 +242,11 @@ class TBHTTPDevice:
         return self._get_data(params=params, endpoint='attributes')
 
     def __subscription_worker(self, endpoint: str, timeout: int = None):
+        """Worker thread for subscription to HTTP API endpoints.
+
+        :param endpoint: The endpoint name.
+        :param timeout: Timeout value in seconds.
+        """
         logger = self.logger.getChild(f'worker.subscription.{endpoint}')
         stop_event = self.__worker[endpoint]['stop_event']
         logger.info('Start subscription to %s updates', endpoint)
@@ -269,7 +279,7 @@ class TBHTTPDevice:
         logger.info('Stop subscription to %s updates', endpoint)
 
     def subscribe(self, endpoint: str, callback: typing.Callable[[dict], None] = None):
-        """Subscribe to updates.
+        """Subscribe to updates from a given endpoint.
 
         :param endpoint: The endpoint to subscribe.
         :param callback: Callback to execute on an update. Takes a dict as only argument.
@@ -277,12 +287,14 @@ class TBHTTPDevice:
         if endpoint not in ['attributes', 'rpc']:
             raise ValueError
         if callback:
+            if not callable(callback):
+                raise TypeError
             self.__worker[endpoint]['callback'] = callback
         self.__worker[endpoint]['stop_event'].clear()
         self.__worker[endpoint]['thread'].start()
 
     def unsubscribe(self, endpoint: str):
-        """Unsubscribe from endpoint.
+        """Unsubscribe from a given endpoint.
 
         :param endpoint: The endpoint to unsubscribe.
         """
@@ -293,7 +305,7 @@ class TBHTTPDevice:
 
     @classmethod
     def provision(cls, host: str, device_name: str, device_key: str, device_secret: str):
-        """Initiate device provisioning and return a client instance.
+        """Initiate device provisioning and return a device instance.
 
         :param host: The root URL to the ThingsBoard instance.
         :param device_name: Name of the device to provision.
@@ -315,7 +327,7 @@ class TBHTTPDevice:
 
 
 class TBHTTPClient(TBHTTPDevice):
-    """Legacy class name"""
+    """Legacy class name."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.logger.critical('TBHTTPClient class is deprecated, please use TBHTTPDevice')

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -57,6 +57,10 @@ class TBHTTPClient:
         """Send attributes to the ThingsBoard HTTP Device API."""
         self.publish_data(attributes, 'attributes')
 
+    def send_rpc(self, name: str, params: dict = None) -> dict:
+        """Send RPC to the ThingsBoard HTTP Device API."""
+        return self.publish_data({'method': name, 'params': params or {}}, 'rpc')
+
     def request_attributes(self, client_keys: list = None, shared_keys: list = None) -> dict:
         """Request attributes from the ThingsBoard HTTP Device API."""
         params = {'client_keys': client_keys, 'shared_keys': shared_keys}

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -3,6 +3,7 @@ import threading
 import logging
 import queue
 import time
+import typing
 from datetime import datetime, timezone
 import requests
 
@@ -34,10 +35,6 @@ class TBHTTPClient:
                 'event': threading.Event()
             }
         }
-        self.logger = logging.getLogger('TBHTTPDevice')
-        self.log_level = 'INFO'
-        self.logger.setLevel(getattr(logging, self.log_level))
-        self.logger.warning('Log level set to %s', self.log_level)
         self.worker = {
             'publish': {
                 'queue': queue.Queue(),
@@ -49,6 +46,22 @@ class TBHTTPClient:
 
     def __repr__(self):
         return f'<ThingsBoard ({self.host}) HTTP client {self.name}>'
+
+    @property
+    def logger(self) -> logging.Logger:
+        """Get the logger instance."""
+        return logging.getLogger('TBHTTPDevice')
+
+    @property
+    def log_level(self) -> str:
+        """Get the log level."""
+        levels = {0: 'NOTSET', 10: 'DEBUG', 20: 'INFO', 30: 'WARNING', 40: 'ERROR', 50: 'CRITICAL'}
+        return levels.get(self.logger.level)
+
+    @log_level.setter
+    def log_level(self, value: typing.Union[int, str]):
+        self.logger.setLevel(value)
+        self.logger.critical('Log level set to %s', self.log_level)
 
     def start_publish_worker(self):
         """Start the publish worker thread."""

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -16,8 +16,13 @@ class TBProvisionFailure(TBHTTPAPIException):
     """Exception raised if device provisioning failed."""
 
 
-class TBHTTPClient:
-    """ThingsBoard HTTP Device API class."""
+class TBHTTPDevice:
+    """ThingsBoard HTTP Device API class.
+
+    :param host: The ThingsBoard hostname.
+    :param token: The device token.
+    :param name: A name for this device. The name is only set locally.
+    """
 
     def __init__(self, host: str, token: str, name: str = None):
         self.__session = requests.Session()
@@ -46,7 +51,7 @@ class TBHTTPClient:
         }
 
     def __repr__(self):
-        return f'<ThingsBoard ({self.host}) HTTP client {self.name}>'
+        return f'<ThingsBoard ({self.host}) HTTP device {self.name}>'
 
     @property
     def host(self) -> str:
@@ -305,3 +310,10 @@ class TBHTTPClient:
         if device['status'] == 'SUCCESS' and device['credentialsType'] == 'ACCESS_TOKEN':
             return cls(host=host, token=device['credentialsValue'], name=device_name)
         raise TBProvisionFailure(device)
+
+
+class TBHTTPClient(TBHTTPDevice):
+    """Legacy class name"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logger.critical('TBHTTPClient class is deprecated, please use TBHTTPDevice')

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -6,10 +6,13 @@ import requests
 class TBHTTPClient:
     """Thingsboard HTTP API Device"""
 
-    def __init__(self, host: str, token: str):
+    def __init__(self, host: str, token: str, name: str = None):
         self.session = requests.Session()
         self.session.headers.update({'Content-Type': 'application/json'})
-        self.api_base_url = f'{host}/api/v1/{token}/'
+        self.token = token
+        self.name = name
+        self.host = host
+        self.api_base_url = f'{self.host}/api/v1/{self.token}/'
 
     def connect(self):
         """Publish an empty telemetry data to ThingsBoard to test the connection."""
@@ -51,5 +54,5 @@ class TBHTTPClient:
         response.raise_for_status()
         device = response.json()
         if device['status'] == 'SUCCESS' and device['credentialsType'] == 'ACCESS_TOKEN':
-            return cls(host=host, token=device['credentialsValue'])
+            return cls(host=host, token=device['credentialsValue'], name=device_name)
         return None

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -14,6 +14,9 @@ class TBHTTPClient:
         self.host = host
         self.api_base_url = f'{self.host}/api/v1/{self.token}/'
 
+    def __repr__(self):
+        return f'<ThingsBoard ({self.host}) HTTP client {self.name}>'
+
     def connect(self):
         """Publish an empty telemetry data to ThingsBoard to test the connection."""
         self.publish_data({}, 'telemetry')

--- a/tb_device_http.py
+++ b/tb_device_http.py
@@ -1,0 +1,25 @@
+"""Thingsboard HTTP API Device module"""
+
+import requests
+
+
+class TBHTTPClient:
+    """Thingsboard HTTP API Device"""
+
+    def __init__(self, host: str, token: str):
+        self.session = requests.Session()
+        self.session.headers.update({'Content-Type': 'application/json'})
+        self.api_base_url = f'{host}/api/v1/{token}/'
+
+    def connect(self):
+        """Publish an empty telemetry data to ThingsBoard to test the connection."""
+        self.publish_data({}, 'telemetry')
+
+    def publish_data(self, data: dict, endpoint: str):
+        """Send data to the ThingsBoard HTTP API."""
+        response = self.session.post(f'{self.api_base_url}/{endpoint}', json=data)
+        response.raise_for_status()
+
+    def send_telemetry(self, telemetry: dict):
+        """Publish telemetry to the ThingsBoard HTTP Device API."""
+        self.publish_data(telemetry, 'telemetry')


### PR DESCRIPTION
I've added all features supported by the HTTP device API. It would be nice to have it in the same package.

Features:
- Supports all features of the HTTP device API.
- Telemetry is pushed to a queue and published in a background thread.

The motivation is that some device running the code are in very restricted networks where ports other than 80 and 443 are blocked (and users have no influence on firewall settings). Therefore it is possible to switch to the HTTP API with very little changes.