### PR TITLE
paho client wait_for_publish only supports the timeout argument for version >= 1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,5 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
     packages=["."],
-    install_requires=['paho-mqtt', 'requests', 'mmh3', 'simplejson'],
+    install_requires=['paho-mqtt>=1.6', 'requests', 'mmh3', 'simplejson'],
     download_url='https://github.com/thingsboard/thingsboard-python-client-sdk/archive/%s.tar.gz' % VERSION)


### PR DESCRIPTION
With paho-mqtt version < 1.6 thingsboard-gateway master branch breaks with the following bug:
```python
Oct 04 18:12:53 opc-ua python3[1615739]: ""2022-10-04 18:12:53" - |ERROR| - [tb_gateway_service.py] - tb_gateway_service - __send_to_storage - 747 - 'attributes'"
Oct 04 18:12:53 opc-ua python3[1615739]: ""2022-10-04 18:12:53" - |ERROR| - [tb_gateway_service.py] - tb_gateway_service - __read_data_from_storage - 858 - wait_for_publish() got an unexpected keyword argument >
Oct 04 18:12:53 opc-ua python3[1615739]: Traceback (most recent call last):
Oct 04 18:12:53 opc-ua python3[1615739]:   File "/usr/lib/python3/dist-packages/thingsboard_gateway/gateway/tb_gateway_service.py", line 852, in __read_data_from_storage
Oct 04 18:12:53 opc-ua python3[1615739]:     success = event.get() == event.TB_ERR_SUCCESS
Oct 04 18:12:53 opc-ua python3[1615739]:   File "/var/lib/thingsboard_gateway/.local/lib/python3.8/site-packages/tb_device_mqtt.py", line 143, in get
Oct 04 18:12:53 opc-ua python3[1615739]:     self.message_info.wait_for_publish(timeout=1)
Oct 04 18:12:53 opc-ua python3[1615739]: TypeError: wait_for_publish() got an unexpected keyword argument 'timeout'
```

See also [this diff](https://github.com/eclipse/paho.mqtt.python/compare/v1.5.1...v1.6.0#diff-5c7d4e9f0de6ef3ae4a9e2bd724e12b368839fc3de296be10e2b7a66f0ff5959R339).

Note, I haven't really tested this change, so please verify it doesn't break something else.