### PR TITLE
fix: rate_limit passed incorrectly

### DIFF
--- a/tb_gateway_mqtt.py
+++ b/tb_gateway_mqtt.py
@@ -35,7 +35,7 @@ class TBGatewayAPI:
 class TBGatewayMqttClient(TBDeviceMqttClient):
     def __init__(self, host, port=1883, username=None, password=None, gateway=None, quality_of_service=1, client_id="",
                  rate_limit="DEFAULT_RATE_LIMIT"):
-        super().__init__(host, port, username, password, quality_of_service, client_id, rate_limit)
+        super().__init__(host, port, username, password, quality_of_service, client_id, rate_limit=rate_limit)
         self.quality_of_service = quality_of_service
         self.__max_sub_id = 0
         self.__sub_dict = {}


### PR DESCRIPTION
`rate_limit` should be the eighth parameter in the initialization function of class TBDeviceMqttClient.