### PR TITLE
Enhanced firmware OTA update

### DIFF
--- a/examples/device/firmware_update.py
+++ b/examples/device/firmware_update.py
@@ -14,9 +14,25 @@
 
 import time
 import logging
-from tb_device_mqtt import TBDeviceMqttClient, FW_STATE_ATTR
+from random import randint
+from tb_device_mqtt import TBDeviceMqttClient, TBFirmwareState, FW_STATE_ATTR, FW_TITLE_ATTR
 
 logging.basicConfig(level=logging.INFO)
+
+def on_firmware_received_example(client, firmware_data, version_to):
+    client.update_firmware_info(state = TBFirmwareState.UPDATING)
+    time.sleep(1)
+
+    with open(client.firmware_info.get(FW_TITLE_ATTR), "wb") as firmware_file:
+        firmware_file.write(firmware_data)
+
+    random_value = randint(0, 5)
+    if random_value > 3:
+        logging.error('Dummy fail! Do not panic, just restart and try again the chance of this fail is ~20%')
+        client.update_firmware_info(state = TBFirmwareState.FAILED, error = "Dummy fail! Do not panic, just restart and try again the chance of this fail is ~20%")
+    else:
+        logging.info("Successfully updated!")
+        client.update_firmware_info(version = version_to, state = TBFirmwareState.UPDATED)
 
 
 def main():
@@ -26,7 +42,7 @@ def main():
     client.get_firmware_update()
 
     # Waiting for firmware to be delivered
-    while not client.current_firmware_info[FW_STATE_ATTR] == 'UPDATED':
+    while not client.current_firmware_info[FW_STATE_ATTR] == TBFirmwareState.UPDATED.value:
         time.sleep(1)
 
     client.disconnect()

--- a/sdk_utils.py
+++ b/sdk_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from random import randint
 from zlib import crc32
 from hashlib import sha256, sha384, sha512, md5
 import logging
@@ -78,8 +77,4 @@ def verify_checksum(firmware_data, checksum_alg, checksum):
     else:
         log.error('Client error. Unsupported checksum algorithm.')
     log.debug(checksum_of_received_firmware)
-    random_value = randint(0, 5)
-    if random_value > 3:
-        log.debug('Dummy fail! Do not panic, just restart and try again the chance of this fail is ~20%')
-        return False
     return checksum_of_received_firmware == checksum

--- a/tb_device_mqtt.py
+++ b/tb_device_mqtt.py
@@ -67,6 +67,7 @@ FW_CHECKSUM_ATTR = "fw_checksum"
 FW_CHECKSUM_ALG_ATTR = "fw_checksum_algorithm"
 FW_SIZE_ATTR = "fw_size"
 FW_STATE_ATTR = "fw_state"
+FW_ERROR_ATTR = "fw_error"
 
 REQUIRED_SHARED_KEYS = f"{FW_CHECKSUM_ATTR},{FW_CHECKSUM_ALG_ATTR},{FW_SIZE_ATTR},{FW_TITLE_ATTR},{FW_VERSION_ATTR}"
 
@@ -532,6 +533,7 @@ class TBDeviceMqttClient:
             "current_" + FW_TITLE_ATTR: "Initial",
             "current_" + FW_VERSION_ATTR: "v0",
             FW_STATE_ATTR: TBFirmwareState.IDLE.value,
+            FW_ERROR_ATTR: ""
         }
         self.__request_id = 0
         self.__firmware_request_id = 0
@@ -554,6 +556,10 @@ class TBDeviceMqttClient:
 
         if state is not None:
             self.current_firmware_info[FW_STATE_ATTR] = state.value
+            if state is TBFirmwareState.FAILED and error is not None:
+                self.current_firmware_info[FW_ERROR_ATTR] = error
+            else:
+                self.current_firmware_info[FW_ERROR_ATTR] = ""
 
         self.send_telemetry(self.current_firmware_info)
 
@@ -796,7 +802,7 @@ class TBDeviceMqttClient:
             sleep(1)
         else:
             log.debug('Checksum verification failed!')
-            self.update_firmware_info(state = TBFirmwareState.FAILED)
+            self.update_firmware_info(state = TBFirmwareState.FAILED, error = "Checksum verification failed!")
             self.__request_firmware_info()
             return
         self.firmware_received = True


### PR DESCRIPTION
Hi everyone,

Previously, the FOTA (Firmware Over-The-Air) feature was implemented only as an internal example and was not accessible to users.

With this PR, the Firmware OTA update functionality is now properly exposed to users through the `on_firmware_received` callback. Users can assign their own function to this callback, which will be triggered when a new firmware is received. This allows for custom handling of the firmware update process.
Users can also report the update status using the update_firmware_info method for better control over the update process.

Additionally, I’ve removed the dummy checksum failure from the library code and moved it to the example. This keeps the core library clean and avoids misleading behavior during actual use.

Feedback is very welcome—please let me know if you have suggestions for improvement or see any potential issues.

Best regards,
Leo Granier
Wiifor