### PR TITLE
Handle nonexistent fw_size attribute

### DIFF
--- a/tb_device_mqtt.py
+++ b/tb_device_mqtt.py
@@ -781,9 +781,9 @@ class TBDeviceMqttClient:
                 sleep(1)
 
                 self.__firmware_request_id = self.__firmware_request_id + 1
-                self.__target_firmware_length = self.firmware_info[FW_SIZE_ATTR]
+                self.__target_firmware_length = self.firmware_info.get(FW_SIZE_ATTR, 0)
                 self.__chunk_count = 0 if not self.__chunk_size else ceil(
-                    self.firmware_info[FW_SIZE_ATTR] / self.__chunk_size)
+                    self.firmware_info.get(FW_SIZE_ATTR, 0) / self.__chunk_size)
                 self.__get_firmware()
 
     def __process_firmware(self):


### PR DESCRIPTION
fw_size may not be present, when issuing an OTA update with a direct URL instead of a filename/blob. Use a sane default of zero bytes for the firmware size, as we are just transferring a URL. This fixes a KeyError exception.